### PR TITLE
Added PHP 5.6 version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,10 @@
             "Verraes\\": ["tests/Verraes"]
         }
     },
+    
+    "require": {
+        "php": "~5.6"
+    },
 
     "require-dev": {
         "phpunit/phpunit": "4.*"


### PR DESCRIPTION
Lambdalicious uses PHP 5.6 features like argument unpacking, we should make sure that the library can be only installed in such environment conditions.
