### PR TITLE
Omikron lists

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 
     "require-dev": {
         "phpunit/phpunit": "~4.3.0",
-        "turanct/omikron": "0.3.0"
+        "turanct/omikron": "0.4.0"
     },
     "config": {
         "bin-dir": "bin"

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 
     "require-dev": {
         "phpunit/phpunit": "~4.3.0",
-        "turanct/omikron": "0.2.0"
+        "turanct/omikron": "0.3.0"
     },
     "config": {
         "bin-dir": "bin"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,10 @@
     "autoload-dev": {
         "psr-4": {
             "Verraes\\": ["tests/Verraes"]
-        }
+        },
+        "files": [
+            "src/Verraes/Lambdalicious/_/omikron.php"
+        ]
     },
 
     "require": {

--- a/src/Verraes/Lambdalicious/_/omikron.php
+++ b/src/Verraes/Lambdalicious/_/omikron.php
@@ -1,5 +1,13 @@
 <?php
 
+atom(@a);
+atom(@b);
+atom(@c);
+atom(@d);
+atom(@e);
+atom(@f);
+atom(@g);
+
 function toBeEqualTo($expected) {
     return function($actual) use($expected) {
         return isequal($actual, $expected)

--- a/src/Verraes/Lambdalicious/_/omikron.php
+++ b/src/Verraes/Lambdalicious/_/omikron.php
@@ -1,0 +1,11 @@
+<?php
+
+function toBeEqualTo($expected) {
+    return function($actual) use($expected) {
+        return isequal($actual, $expected)
+            ? true
+            : "Expected values to be equal, instead got:".diff(show($actual), show($expected))
+        ;
+    };
+}
+

--- a/src/Verraes/Lambdalicious/datastructures.php
+++ b/src/Verraes/Lambdalicious/datastructures.php
@@ -9,6 +9,7 @@ atom(@nil);
 atom(@islist);
 atom(@al);
 atom(@la);
+atom(@show);
 
 /**
  * Construct a pair
@@ -113,5 +114,21 @@ function la($list)
         !islist($list) ? raise("la() is only defined for lists") :
         (isempty($list) ? [] :
         array_merge([head($list)], la(tail($list))))
+    ;
+}
+
+/**
+ * Return a string representation of a datastructure
+ *
+ * @param mixed $data
+ *
+ * @return string
+ */
+function show($data)
+{
+    return
+        islist($data) ? '(' . implode(', ', la(map(show, $data))) . ')' :
+        (ispair($data) ? '(' . show(head($data)) . ' . ' . show(tail($data)) . ')':
+        print_r($data, true))
     ;
 }

--- a/topics/topic-lists.php
+++ b/topics/topic-lists.php
@@ -207,14 +207,13 @@ within('lists',
                 toBe(c)
             );
         }),
-        it('throws an exception when index is not found', function() {
-            try {
-                pick(l(a, b, c, d), 5);
-            } catch (Exception $e) {
-                return true;
-            }
-
-            return false;
+        it('throws an exception when index is not found', function() { return
+            expectToThrow(
+                function() {
+                    pick(l(a, b, c, d), 5);
+                },
+                '_λlicious_failed'
+            );
         })
     )
 );

--- a/topics/topic-lists.php
+++ b/topics/topic-lists.php
@@ -19,11 +19,8 @@ within('lists',
     describe('cons',
         it('builds lists', function() { return
             expect(
-                isequal(
-                    cons(@a, l(@b, @c)),
-                    l(@a, @b, @c)
-                ),
-                toBeTrue()
+                cons(@a, l(@b, @c)),
+                toBeEqualTo(l(@a, @b, @c))
             );
         })
     ),
@@ -37,20 +34,14 @@ within('lists',
     describe('tail',
         it('returns the list without its first element', function() { return
             expect(
-                isequal(
-                    tail(l(@a, @b, @c)),
-                    l(@b, @c)
-                ),
-                toBeTrue()
+                tail(l(@a, @b, @c)),
+                toBeEqualTo(l(@b, @c))
             );
         }),
         it('returns an empty list for a list with one element', function() { return
             expect(
-                isequal(
-                    tail(l(@a)),
-                    l()
-                ),
-                toBeTrue()
+                tail(l(@a)),
+                toBeEqualTo(l())
             );
         })
     ),
@@ -67,38 +58,26 @@ within('lists',
     describe('concat',
         it('returns an emtpy list, without arguments', function() { return
             expect(
-                isequal(
-                    concat(),
-                    l()
-                ),
-                toBeTrue()
+                concat(),
+                toBeEqualTo(l())
             );
         }),
         it('returns the list, when given a single list', function() { return
             expect(
-                isequal(
-                    concat(l(@a, @b, @c)),
-                    l(@a, @b, @c)
-                ),
-                toBeTrue()
+                concat(l(@a, @b, @c)),
+                toBeEqualTo(l(@a, @b, @c))
             );
         }),
         it('returns a list, when given 2 lists', function() { return
             expect(
-                isequal(
-                    concat(l(@a, @b, @c), l(@d, @e, @f, @g)),
-                    l(@a, @b, @c, @d, @e, @f, @g)
-                ),
-                toBeTrue()
+                concat(l(@a, @b, @c), l(@d, @e, @f, @g)),
+                toBeEqualTo(l(@a, @b, @c, @d, @e, @f, @g))
             );
         }),
         it('returns a list, when given multiple lists', function() { return
             expect(
-                isequal(
-                    concat(l(@a, @b), l(@c, @d), l(@e, @f)),
-                    l(@a, @b, @c, @d, @e, @f)
-                ),
-                toBeTrue()
+                concat(l(@a, @b), l(@c, @d), l(@e, @f)),
+                toBeEqualTo(l(@a, @b, @c, @d, @e, @f))
             );
         })
     )

--- a/topics/topic-lists.php
+++ b/topics/topic-lists.php
@@ -80,5 +80,141 @@ within('lists',
                 toBeEqualTo(l(a, b, c, d, e, f))
             );
         })
+    ),
+
+    describe('contains1',
+        it('returns true, when given a list with one element', function() { return
+            expect(contains1(l(a)), toBeTrue());
+        }),
+        it('returns false, when given a list with more than two elements', function() { return
+            expect(contains1(l(a, b, c)), toBeFalse());
+        }),
+        it('returns false, when given an empty list', function() { return
+            expect(contains1(l()), toBeFalse());
+        })
+    ),
+
+    describe('reverse',
+        it('reverses an empty list', function() { return
+            expect(reverse(l()), toBeEqualTo(l()));
+        }),
+        it('reverses a list with one element', function() { return
+            expect(reverse(l(a)), toBeEqualTo(l(a)));
+        }),
+        it('reverses a list with more than one element', function() { return
+            expect(reverse(l(a, b, c, d)), toBeEqualTo(l(d, c, b, a)));
+        })
+    ),
+
+    describe('max_by',
+        it('uses a callback to determine the max element of a list', function() { return
+            expect(
+                max_by(@strlen, l('lambda', 'calculus', 'rocks')),
+                toBe('calculus')
+            );
+        }),
+        it('supports partial application', function() {
+            $longestString = max_by(@strlen, __);
+
+            return expect(
+                $longestString(l('lambda', 'calculus', 'rocks')),
+                toBe('calculus')
+            );
+        })
+    ),
+
+    describe('min_by',
+        it('uses a callback to determine the min element of a list', function() { return
+            expect(
+                min_by(@strlen, l('lambda', 'calculus', 'rocks')),
+                toBe('rocks')
+            );
+        }),
+        it('supports partial application', function() {
+            $shortestString = min_by(@strlen, __);
+
+            return expect(
+                $shortestString(l('lambda', 'calculus', 'rocks')),
+                toBe('rocks')
+            );
+        })
+    ),
+
+    describe('zip',
+        it('creates a list of pairs from a pair of lists', function() {
+            $list1 = l(@keep, @lambda);
+            $list2 = l(@calm, @on, @that, @whisky, @bottle);
+
+            return expect(
+                zip($list1, $list2),
+                toBeEqualTo(l(pair(@keep, @calm), pair(@lambda, @on)))
+            );
+        })
+    ),
+
+    describe('zipWith',
+        it('creates a list by calling a callback with parameters from two lists', function() {
+            $list1 = l(1, 2, 3, 4);
+            $list2 = l(4, 3, 2);
+
+            return expect(
+                zipWith(add, $list1, $list2),
+                toBeEqualTo(l(5, 5, 5))
+            );
+        })
+    ),
+
+    describe('map',
+        it('returns an empty list when given an empty list', function() { return
+            expect(
+                map(add(1, __), l()),
+                toBeEqualTo(l())
+            );
+        }),
+        it('applies a function to every element of a list', function() { return
+            expect(
+                map(add(1, __), l(1, 2, 3, 4)),
+                toBeEqualTo(l(2, 3, 4, 5))
+            );
+        })
+    ),
+
+    describe('filter',
+        it('returns an empty list when given an empty list', function() { return
+            expect(
+                filter(isequal(2, __), l()),
+                toBeEqualTo(l())
+            );
+        }),
+        it('filters a list using a predicate', function() { return
+            expect(
+                filter(isequal(2, __), l(1, 2, 3, 2, 1, 2, 3)),
+                toBeEqualTo(l(2, 2, 2))
+            );
+        })
+    ),
+
+    describe('pick',
+        it('returns the first element of a list, for index 0', function() { return
+            expect(
+                pick(l(a, b, c, d), 0),
+                toBe(a)
+            );
+        }),
+        it('returns the n+1th element of a list, for index n', function() { return
+            expect(
+                pick(l(a, b, c, d), 2),
+                toBe(c)
+            );
+        }),
+        it('throws an exception when index is not found', function() {
+            try {
+                pick(l(a, b, c, d), 5);
+            } catch (Exception $e) {
+                return true;
+            }
+
+            return false;
+        })
     )
 );

--- a/topics/topic-lists.php
+++ b/topics/topic-lists.php
@@ -12,35 +12,35 @@ within('lists',
             expect(isempty(l()), toBeTrue());
         }),
         it('returns false for non-empty lists', function() { return
-            expect(isempty(l(@a, @b, @c)), toBeFalse());
+            expect(isempty(l(a, b, c)), toBeFalse());
         })
     ),
 
     describe('cons',
         it('builds lists', function() { return
             expect(
-                cons(@a, l(@b, @c)),
-                toBeEqualTo(l(@a, @b, @c))
+                cons(a, l(b, c)),
+                toBeEqualTo(l(a, b, c))
             );
         })
     ),
 
     describe('head',
         it('returns the first S-expression', function() { return
-            expect(head(l(@a, @b, @c)), toBe(@a));
+            expect(head(l(a, b, c)), toBe(a));
         })
     ),
 
     describe('tail',
         it('returns the list without its first element', function() { return
             expect(
-                tail(l(@a, @b, @c)),
-                toBeEqualTo(l(@b, @c))
+                tail(l(a, b, c)),
+                toBeEqualTo(l(b, c))
             );
         }),
         it('returns an empty list for a list with one element', function() { return
             expect(
-                tail(l(@a)),
+                tail(l(a)),
                 toBeEqualTo(l())
             );
         })
@@ -51,7 +51,7 @@ within('lists',
             expect(length(l()), toBe(0));
         }),
         it('returns returns the number of list elements for non-empty lists', function() { return
-            expect(length(l(@a, @b, @c, @d)), toBe(4));
+            expect(length(l(a, b, c, d)), toBe(4));
         })
     ),
 
@@ -64,20 +64,20 @@ within('lists',
         }),
         it('returns the list, when given a single list', function() { return
             expect(
-                concat(l(@a, @b, @c)),
-                toBeEqualTo(l(@a, @b, @c))
+                concat(l(a, b, c)),
+                toBeEqualTo(l(a, b, c))
             );
         }),
         it('returns a list, when given 2 lists', function() { return
             expect(
-                concat(l(@a, @b, @c), l(@d, @e, @f, @g)),
-                toBeEqualTo(l(@a, @b, @c, @d, @e, @f, @g))
+                concat(l(a, b, c), l(d, e, f, g)),
+                toBeEqualTo(l(a, b, c, d, e, f, g))
             );
         }),
         it('returns a list, when given multiple lists', function() { return
             expect(
-                concat(l(@a, @b), l(@c, @d), l(@e, @f)),
-                toBeEqualTo(l(@a, @b, @c, @d, @e, @f))
+                concat(l(a, b), l(c, d), l(e, f)),
+                toBeEqualTo(l(a, b, c, d, e, f))
             );
         })
     )

--- a/topics/topic-lists.php
+++ b/topics/topic-lists.php
@@ -1,0 +1,105 @@
+<?php return
+
+within('lists',
+    describe('empty list',
+        it('equals itself', function() { return
+            expect(l(), toBe(l()));
+        })
+    ),
+
+    describe('isempty',
+        it('returns true for empty lists', function() { return
+            expect(isempty(l()), toBeTrue());
+        }),
+        it('returns false for non-empty lists', function() { return
+            expect(isempty(l(@a, @b, @c)), toBeFalse());
+        })
+    ),
+
+    describe('cons',
+        it('builds lists', function() { return
+            expect(
+                isequal(
+                    cons(@a, l(@b, @c)),
+                    l(@a, @b, @c)
+                ),
+                toBeTrue()
+            );
+        })
+    ),
+
+    describe('head',
+        it('returns the first S-expression', function() { return
+            expect(head(l(@a, @b, @c)), toBe(@a));
+        })
+    ),
+
+    describe('tail',
+        it('returns the list without its first element', function() { return
+            expect(
+                isequal(
+                    tail(l(@a, @b, @c)),
+                    l(@b, @c)
+                ),
+                toBeTrue()
+            );
+        }),
+        it('returns an empty list for a list with one element', function() { return
+            expect(
+                isequal(
+                    tail(l(@a)),
+                    l()
+                ),
+                toBeTrue()
+            );
+        })
+    ),
+
+    describe('length',
+        it('returns 0 for an empty list', function() { return
+            expect(length(l()), toBe(0));
+        }),
+        it('returns returns the number of list elements for non-empty lists', function() { return
+            expect(length(l(@a, @b, @c, @d)), toBe(4));
+        })
+    ),
+
+    describe('concat',
+        it('returns an emtpy list, without arguments', function() { return
+            expect(
+                isequal(
+                    concat(),
+                    l()
+                ),
+                toBeTrue()
+            );
+        }),
+        it('returns the list, when given a single list', function() { return
+            expect(
+                isequal(
+                    concat(l(@a, @b, @c)),
+                    l(@a, @b, @c)
+                ),
+                toBeTrue()
+            );
+        }),
+        it('returns a list, when given 2 lists', function() { return
+            expect(
+                isequal(
+                    concat(l(@a, @b, @c), l(@d, @e, @f, @g)),
+                    l(@a, @b, @c, @d, @e, @f, @g)
+                ),
+                toBeTrue()
+            );
+        }),
+        it('returns a list, when given multiple lists', function() { return
+            expect(
+                isequal(
+                    concat(l(@a, @b), l(@c, @d), l(@e, @f)),
+                    l(@a, @b, @c, @d, @e, @f)
+                ),
+                toBeTrue()
+            );
+        })
+    )
+);


### PR DESCRIPTION
- Add a lambdalicious extension to omikron so we can use the `isequal()` function easily as an assertion
- Add some omikron tests for lists (they're not all there yet)
- Add a `show()` function to lambdalicious, which shows a textual representation of all datastructures (that we can use in diffs, or for dumps, maybe we can alter `dump()` to use it too). Also, i guess i took the term "show" from haskell, but to keep it lispy maybe `quote()` is better?

```sh
topics: 2
features: 10
assertions: 19

FAILED: lists: concat returns a list, when given multiple lists
Expected values to be equal, instead got:
--- Actual
+++ Expected
@@ @@
-(a, b, c, d, e, f)
+(a, b, c, d, e, 1)
```