### PR TITLE
Omikron examples

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 
     "require-dev": {
         "phpunit/phpunit": "~4.3.0",
-        "turanct/omikron": "0.4.0"
+        "turanct/omikron": "0.5.0"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Verraes/Lambdalicious/_/omikron.php
+++ b/src/Verraes/Lambdalicious/_/omikron.php
@@ -17,3 +17,6 @@ function toBeEqualTo($expected) {
     };
 }
 
+function assertCallback($file, $line, $code) {
+    throw new _λlicious_failed('Assertion failed in ' . $file . ', line ' . $line);
+}

--- a/topics/topic-examples.php
+++ b/topics/topic-examples.php
@@ -1,0 +1,22 @@
+<?php
+
+assert_options(ASSERT_WARNING, 0);
+assert_options(ASSERT_CALLBACK, 'assertCallback');
+
+return within('lambdalicious',
+    describe('example',
+        it('serves as a test', function() {
+            $dir = __DIR__ . '/../examples/';
+            $files = array_diff(scandir($dir), ['..', '.', '_']);
+
+            return expectNotToThrow(function() use ($files, $dir) {
+                array_walk(
+                    $files,
+                    function($file) use ($dir) {
+                        include($dir.$file);
+                    }
+                );
+            });
+        })
+    )
+);


### PR DESCRIPTION
Use the lambdalicious examples in `/examples` as a self-testing example bundle.