### PR TITLE
Add a trampoline, a higher order function resolving stack overflows

### DIFF
--- a/src/Verraes/Lambdalicious/higherorder.php
+++ b/src/Verraes/Lambdalicious/higherorder.php
@@ -102,3 +102,26 @@ function recurse(callable $function)
         return call($function, cons($function, al($params)));
     };
 }
+
+/**
+ * Trampoline
+ *
+ * Allows writing tail-recursive functions without stack overflows
+ * At the moment it only works with functions that do NOT return functions
+ *
+ * @param callable $function The tail-recursive function we want to optimize
+ *
+ * @return callable
+ */
+function trampoline(callable $function)
+{
+    return function(...$params) use ($function) {
+        $result = call($function, al($params));
+
+        while (is_callable($result)) {
+            $result = call($result, l());
+        }
+
+        return $result;
+    };
+}

--- a/topics/topic-higherorder.php
+++ b/topics/topic-higherorder.php
@@ -62,6 +62,37 @@ within('higher order',
 
             return expect($fib(7), toBe(13));
         })
+    ),
+
+    describe('trampoline',
+        it('makes tail recursion possible, without stack overflows', function() {
+            // Define a simple length function, to get the length of an array
+            $length_ = recurse(function($length_, $a, $acc = 0) {
+                return empty($a)
+                    ? $acc
+                    // Instead of returning the result of a recursive call, we return
+                    // a closure representing the recursive call, which can be called
+                    // out of context, one stack frame up.
+                    : function() use ($length_, $a, $acc) {
+                        return $length_($length_, array_slice($a, 1), $acc + 1);
+                      }
+                ;
+            });
+
+            $length = trampoline($length_);
+
+            // The normal implementation would blow the stack (uncomment to try):
+            /*
+            $length = recurse(function($length, $a, $acc = 0) {
+                return empty($a)
+                    ? $acc
+                    : $length($length, array_slice($a, 1), $acc + 1)
+                ;
+            });
+            */
+
+            return expect($length(range(1, 1000)), toBe(1000));
+        })
     )
 );
 


### PR DESCRIPTION
Using the trampoline combinator, we can write tail-recursive functions
in a way that doesn't blow the stack. This way, php will let us define
functions in the only way we like! RECURSIVESHIZZLEZ!